### PR TITLE
fix bug where PHP_OS constants not handled right

### DIFF
--- a/src/SoftekBarcodeAPI.php
+++ b/src/SoftekBarcodeAPI.php
@@ -153,10 +153,12 @@ class SoftekBarcodeAPI
     private function getIntegerType(): string
     {
         switch (PHP_OS) {
-            case 'Linux':
-                return 'long';
-            case 'Windows':
-                return "int";
+            case "WIN32":
+            case "WINNT":
+            case "Windows":
+                return 'int';
+            case "Linux":
+                return "long";
             default:
                 throw new SoftekUnsupportedException(
                     sprintf("No integer type is supported for operating system %s", PHP_OS)


### PR DESCRIPTION
This pull request will fix a bug where the PHP_OS constant is not handled right. On Windows system mosttimes the constant return WINNT. That return value produces a error within the runtime  